### PR TITLE
NPE-2223 Update isort command to add src path to determine root directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,4 @@ use_parentheses = true
 max-line-length = 120
 
 [tool.pylint.messages_control]
-disable = "W1309" # disable logging-fstring-interpolation
+disable = "W1203" # disable logging-fstring-interpolation

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -6,7 +6,7 @@ CONFIG_FILE_PATH="$(pwd)/.github/pyproject.toml"
 if [ ! -z "${files}" ]; then
     echo "Formatting modified python files using black before committing them ..."
     black --config="$CONFIG_FILE_PATH" --exclude venv $files
-    isort --settings-path="$CONFIG_FILE_PATH" $files
+    isort --settings-path="$CONFIG_FILE_PATH" --src-path="$(pwd)" $files
     git add .
     echo "Running pylint on modified python files before committing them ..."
     pylint --fail-under=10 --rcfile="$CONFIG_FILE_PATH" $files


### PR DESCRIPTION
# Problem

The ordering of the imports is not coming correctly. 3rd party imports are coming with local project imports.
This is happening because we have passed the `settings-path` as an argument to isort. Due to this, it is considering the path containing the settings file as the root and is not able to compute the 3rd party packages.

# Solution

We are passing the `src-path` along with the `settings-path` to determine the root path.

### Deployment Steps

N/A

### Post-Deployment Steps

N/A

# Checklist

- [x] Self-review done
- [ ] Test cases for changes added
- [ ] Passed all test cases (coverage >= 50%)
- [x] Code meets coding standards
- [x] Code is properly documented
