### PR TITLE
NPE-2223 Update pylint config to fix import errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ max-line-length = 120
 
 [tool.pylint.messages_control]
 disable = "W1203" # disable logging-fstring-interpolation
+
+[tool.pylint.master]
+init-hook='import sys; sys.path.append("./")'


### PR DESCRIPTION
# Problem

While running pylint, it gives an import error even if the import is correct.

# Solution

Specify path in pyproject.toml file

### Deployment Steps

N/A

### Post-Deployment Steps

N/A

# Checklist

- [ ] Self-review done
- [ ] Test cases for changes added
- [ ] Passed all test cases (coverage >= 50%)
- [ ] Code meets coding standards
- [ ] Code is properly documented
