### PR TITLE
[NPE-3602]: added float_to_top flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ line_length = 120
 multi_line_output = 3
 profile = "black"
 use_parentheses = true
+float_to_top=true
 
 [tool.pylint.format]
 max-line-length = 120


### PR DESCRIPTION
# Problem

isort was not sorting imports if any part of code is written between them.

# Solution

Set float_to_top flag as true in isort configurations.

### Deployment Steps

<!--[
  Are there any deployment steps that need to be executed/documented?
]-->

### Post-Deployment Steps

<!--[
  Are there any post-deploy steps that need to be executed/documented?
]-->

# Checklist

- [x] Self-review done
- [ ] Test cases for changes added
- [ ] Passed all test cases (coverage >= 50%)
- [x] Code meets coding standards
- [x] Code is properly documented
